### PR TITLE
fix: tosql issue causing 500 error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+dump:
+	DUMP_UPDATES=1 cargo run
+silent:
+	cargo run
+dump-verbose:
+	DUMP_UPDATES=1 DUMP_UPDATES_DATA=1 cargo run
+
+.PHONY:
+	silent dump dump-verbose

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,9 @@ async fn account_update(
     item: Json<UpdateAccount>,
 ) -> (StatusCode, String) {
     let storable = UpdateAccountStorable::from(item.0);
-    // eprintln!("Storing {:#?}", storable);
+    if std::env::var("DUMP_UPDATES").is_ok() {
+        eprintln!("{:#?}", storable);
+    }
     let db = state.db.lock().expect("mutex was poisoned");
     match db.insert_account_update(storable) {
         Ok(_) => (StatusCode::OK, "OK".to_string()),

--- a/src/update_account.rs
+++ b/src/update_account.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 
-use crate::{pubkey_string_from_bytes, tx_signature_string_from_bytes};
+use crate::{
+    base64_encode, pubkey_string_from_bytes, tx_signature_string_from_bytes,
+};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct UpdateAccount {
@@ -37,7 +39,7 @@ impl std::fmt::Debug for UpdateAccountStorable {
             .field("owner", &self.owner)
             .field("executable", &self.executable)
             .field("rent_epoch", &self.rent_epoch)
-            .field("data_len", &self.data.len())
+            .field("data", &base64_encode(&self.data))
             .field("write_version", &self.write_version)
             .field("txn_signature", &self.txn_signature)
             .finish()

--- a/src/update_account.rs
+++ b/src/update_account.rs
@@ -32,6 +32,11 @@ pub struct UpdateAccountStorable {
 
 impl std::fmt::Debug for UpdateAccountStorable {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let data = if std::env::var("DUMP_UPDATES_DATA").is_ok() {
+            base64_encode(&self.data)
+        } else {
+            format!("<{} bytes>", self.data.len())
+        };
         f.debug_struct("UpdateAccountStorable")
             .field("slot", &self.slot)
             .field("pubkey", &self.pubkey)
@@ -39,7 +44,7 @@ impl std::fmt::Debug for UpdateAccountStorable {
             .field("owner", &self.owner)
             .field("executable", &self.executable)
             .field("rent_epoch", &self.rent_epoch)
-            .field("data", &base64_encode(&self.data))
+            .field("data", &data)
             .field("write_version", &self.write_version)
             .field("txn_signature", &self.txn_signature)
             .finish()


### PR DESCRIPTION
## Summary

The store had issues stroing the epoch since it doesn't fit into an INTEGER which then resulted
in a 500 (which in turn crashed Geyser). That has been fixed.

Additionally we added a way to config dump and verbosity along with a `Makefile` containing
tasks for those options
